### PR TITLE
Fix bug assigning newly created player to both currentGame player instances. Change win state to allow losing player to have first turn in next game

### DIFF
--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ class Game{
   addPlayer(playerData){
     if(this.currentTurn === 0){
       this.playerOne = playerData;
-    } else {
+    } else if(this.currentTurn === 1){
       this.playerTwo = playerData;
     }
   }
@@ -33,21 +33,23 @@ class Game{
       this.playerOneSections.push(target);
       this.gameBoard[target].innerHTML = `<div class = token>${this.playerOne.token}</div>`;
       this.updateGameStatus(this.playerTwo, 2);
-      this.currentTurn = 1;
+      changeCurrentTurn();
       this.checkGameConditions();
     } else {
       this.playerTwoSections.push(target);
       this.gameBoard[target].innerHTML = `<div class = token>${this.playerTwo.token}</div>`;
       this.updateGameStatus(this.playerOne, 2);
-      this.currentTurn = 0;
+      changeCurrentTurn();
       this.checkGameConditions();
     }
   }
+  
   updateGameStatus(player, winCheck) {
     if(winCheck === 0){
       gameStateDisplay.innerText = `It's a draw! ${player.name}, pick a square to start a new game!`;
     }else if(winCheck === 1){
-      gameStateDisplay.innerText = `${player.name} wins! ${player.name}, pick a square to start a new game!`
+      var losingPlayer = this.checkLosingPlayer(player);
+      gameStateDisplay.innerText = `${player.name} wins! ${losingPlayer.name}, pick a square to start a new game!`
     } else {
       gameStateDisplay.innerText = `It's ${player.name}'s turn!`;
     }
@@ -58,15 +60,23 @@ class Game{
     for(var i = 0; i < this.winConditions.length; i++){
       if(this.winConditions[i].every(index => this.playerOneSections.includes(index))){
         this.playerOne.updateStats();
-        this.winAnimation(this.winConditions[i], this.playerOne);
+        this.winState(this.winConditions[i], this.playerOne);
       } else if (this.winConditions[i].every(index => this.playerTwoSections.includes(index))){
         this.playerTwo.updateStats();
-        this.winAnimation(this.winConditions[i], this.playerTwo);
+        this.winState(this.winConditions[i], this.playerTwo);
       }
     }
   }
 
-  winAnimation(winningSections, winningPlayer){
+  checkLosingPlayer(player){
+    if(this.playerOne === player){
+      return this.playerTwo;
+    } else {
+      return this.playerOne;
+    }
+  }
+
+  winState(winningSections, winningPlayer){
     for(var i =0; i < winningSections.length; i++){
       var toAnimate = winningSections[i];
       this.gameBoard[toAnimate].childNodes[0].classList.add("token-spin");
@@ -87,7 +97,7 @@ class Game{
     this.playerOneSections = [];
     this.playerTwoSections = [];
     setTimeout(currentGame.clearGameBoard, 1500);
-    this.currentTurn = 0;
+    updatePlayerDisplay(winningPlayer);
   }
 
   restartGame(){

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <p class="player-select-status" id=0>Player One: Create new player or select from saved</p>
       <form class="start-select" action="index.html" method="post">
         <p>Create a Player!</p>
-        <input type="text" id="player-name" placeholder="Enter your name">
+        <input type="text" id="player-name" placeholder="Enter your name" autocomplete="off">
         <br><br>
         <select id="player-token">
           <option selected disabled>Choose your token</option>

--- a/main.js
+++ b/main.js
@@ -30,22 +30,18 @@ function onLoad(){
 }
 
 function createPlayerFromStorage(playerKey){
-  var playerData = JSON.parse(localStorage.getItem(playerKey));
-  var id = playerData.id;
-  var name = playerData.name;
-  var token = playerData.token;
-  var wins = playerData.wins;
-  var existingPlayer = new Player(id, name, token, wins);
+  var player = JSON.parse(localStorage.getItem(playerKey));
+  var existingPlayer = new Player(player.id, player.name, player.token, player.wins);
   return existingPlayer;
 }
 
 function createNewPlayer(){
-  var playerName = newPlayerName.value;
-  var playerSymbol = newPlayerSymbol.value;
-  var newPlayer = new Player(Date.now(), playerName, playerSymbol, 0);
+  var newPlayer = new Player(Date.now(), newPlayerName.value, newPlayerSymbol.value, 0);
   currentGame.addPlayer(newPlayer);
   populatePlayerArea(newPlayer);
   newPlayer.saveToStorage();
+  var newOption = createPlayerOption(newPlayer);
+  existingPlayerSelection.appendChild(newOption);
   return newPlayer;
 }
 
@@ -64,7 +60,7 @@ function eventTargetIdentifier(event){
   event.preventDefault();
   var target = event.target;
   if(target.classList.contains("create-new-player")){
-    currentGame.addPlayer(createNewPlayer())
+    createNewPlayer()
   } else if(target.classList.contains("choose-existing-player")){
     var playerKey = existingPlayerSelection.value;
     var existingPlayer = createPlayerFromStorage(playerKey);
@@ -79,6 +75,7 @@ function eventTargetIdentifier(event){
   } else if(target.classList.contains("select-players")){
     menuBlur();
     changePage();
+    existingPlayerSelection.value = 'Select a player!';
   } else if(target.classList.contains("restart-game")){
     menuBlur();
     currentGame.restartGame();
@@ -86,18 +83,26 @@ function eventTargetIdentifier(event){
 }
 
 function populatePlayerArea(playerData){
-    if(currentGame.currentTurn === 0){
+  if(currentGame.currentTurn === 0){
+    updatePlayerDisplay(playerData);
+    playerSelectStatus.innerText = "Player Two: Create new player or select from saved";
+    changeCurrentTurn();
+    gameStateDisplay.innerText = `${currentGame.playerOne.name}'s Turn!`
+  } else {
+    updatePlayerDisplay(playerData);
+    playerSelectStatus.innerText = "Player One: Create new player or select from saved";
+    changeCurrentTurn();
+    changePage();
+  }
+}
+
+function updatePlayerDisplay(playerData){
+  if(currentGame.playerOne === playerData){
     playerOneNameDisplay.innerText = `${currentGame.playerOne.name} ${currentGame.playerOne.token}`;
     playerOneScoreDisplay.innerText = `${currentGame.playerOne.wins} wins`;
-    playerSelectStatus.innerText = "Player Two: Create new player or select from saved";
-    currentGame.currentTurn = 1;
-    gameStateDisplay.innerText = `${currentGame.playerOne.name}'s Turn!`
   } else {
     playerTwoNameDisplay.innerText = `${currentGame.playerTwo.name} ${currentGame.playerTwo.token}`;
     playerTwoScoreDisplay.innerText = `${currentGame.playerTwo.wins} wins`;
-    playerSelectStatus.innerText = "Player One: Create new player or select from saved";
-    currentGame.currentTurn = 0;
-    changePage();
   }
 }
 
@@ -106,6 +111,13 @@ function changePage(event){
   gamePage.classList.toggle("hidden");
 }
 
+function changeCurrentTurn(){
+  if(currentGame.currentTurn === 0){
+    currentGame.currentTurn = 1
+  } else {
+    currentGame.currentTurn = 0
+  }
+}
 
 function menuBlur(){
   optionsMenu.classList.toggle("hidden");


### PR DESCRIPTION
#### What does  this PR do?

This PR fixed an issue with second player creating a new player, which assigned the second player to both player instances of the game. This also changes the win state functionality, allowing the losing player to go first in the next game.

#### Where should the reviewer start?

Look at code deleted in the main.js file. game.js player instance assignment was occurring twice when a new player is created, once in createNewPlayer function, and again in populatePlayerArea function. This PR removes the player instance assignment from the populatePlayerArea function.

### Is this a bug fix or a feature?

Bug fix.

#### How should this be manually tested?

In browser, experiment with different variations of player one and two creating new players and choosing existing players.
