### PR TITLE
Add delete player functionality to start page, removing player from storage and existing player drop down menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,11 +71,19 @@ function createPlayerOption(existingPlayer){
   var id = existingPlayer.id;
   var newOption = document.createElement("option");
   var optionName = document.createTextNode(name);
+  newOption.setAttribute('id', id);
   newOption.setAttribute("value", id);
   newOption.appendChild(optionName);
   return newOption;
 }
 
+function deletePlayer(playerKey){
+  var player = JSON.parse(localStorage.getItem(playerKey));
+  var optionToDelete = document.getElementById(playerKey);
+  var existingPlayer = new Player(player.id, player.name, player.token, player.wins);
+  existingPlayer.deleteFromStorage();
+  existingPlayerSelection.removeChild(optionToDelete);
+}
 
 function eventHandler(event){
   event.preventDefault();
@@ -89,6 +97,8 @@ function eventHandler(event){
     populatePlayerArea(existingPlayer);
   } else if(target.classList.contains("game-section")){
     currentGame.playerTurn(parseInt(target.id));
+  } else if(target.classList.contains("delete-player")){
+    deletePlayer(existingPlayerSelection.value);
   } else if(target.classList.contains("options-button")){
     removeAllPreviewEvent();
     menuBlur();
@@ -100,7 +110,7 @@ function eventHandler(event){
     restorePreviewTokenEvent();
     currentGame.restartGame();
     changePage();
-    existingPlayerSelection.value = 'Select a player!';
+    updateExistingPlayerDisplay();
   } else if(target.classList.contains("restart-game")){
     menuBlur();
     restorePreviewTokenEvent();
@@ -111,12 +121,14 @@ function eventHandler(event){
 function populatePlayerArea(playerData){
   if(currentGame.currentTurn === 0){
     updatePlayerDisplay(playerData);
-    playerSelectStatus.innerText = "Player Two: Create new player or select from saved";
+    // playerSelectStatus.innerText = "Player Two: Create new player or select from saved";
+    updateSelectStatus("Player Two");
     changeCurrentTurn();
     gameStateDisplay.innerText = `${currentGame.playerOne.name}'s Turn!`
   } else {
     updatePlayerDisplay(playerData);
-    playerSelectStatus.innerText = "Player One: Create new player or select from saved";
+    // playerSelectStatus.innerText = "Player One: Create new player or select from saved";
+    updateSelectStatus("Player One");
     changeCurrentTurn();
     changePage();
   }
@@ -130,6 +142,14 @@ function updatePlayerDisplay(playerData){
     playerTwoNameDisplay.innerText = `${currentGame.playerTwo.name} ${currentGame.playerTwo.token}`;
     playerTwoScoreDisplay.innerText = `${currentGame.playerTwo.wins} wins`;
   }
+}
+
+function updateSelectStatus(playerSelecting){
+  playerSelectStatus.innerText = `${playerSelecting}: Create new player or select from saved`;
+}
+
+function updateExistingPlayerDisplay(){
+  existingPlayerSelection.value = 'Select a player!';
 }
 
 function changePage(event){


### PR DESCRIPTION
#### What does  this PR do?

This PR adds functionality to the delete player button on start page. Deletes player from local storage and from the existing player drop down menu.

#### Where should the reviewer start?

Familiarize yourself with the deleteFromStorage function in player.js,  how it is called in the deletePlayer function on main.js. Examine how option is removed from the drop down menu with the removeChild method in deletePlayer function.

### Is this a bug fix or a feature?

Feature.

#### How should this be manually tested?

In browser, create new player and check localStorage and the existing player drop down menu. Upon deletion, ensure that it is removed from both localStorage and existing player drop down menu.
