### PR TITLE
Add restoreUnusedPreviewToken function to keep player inhabited sections from populating with additional token

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,7 +103,7 @@ function eventHandler(event) {
     removeAllPreviewEvent();
     menuBlur();
   } else if (target.classList.contains('exit-menu')) {
-    restorePreviewTokenEvent();
+    restoreUnusedPreviewToken();
     menuBlur();
   } else if (target.classList.contains('select-players')) {
     menuBlur();
@@ -226,5 +226,22 @@ function restorePreviewTokenEvent() {
   })
   gameBoardSection.forEach(section => {
     section.addEventListener('mouseleave', removePreviewToken);
+  })
+}
+
+function restoreUnusedPreviewToken() {
+  gameBoardSection.forEach(section => {
+    if (section.childNodes.length > 0) {
+      return;
+    } else {
+      section.addEventListener('mouseenter', previewToken);
+    }
+  })
+  gameBoardSection.forEach(section => {
+    if (section.childNodes.length > 0) {
+      return;
+    } else {
+    section.addEventListener('mouseleave', removePreviewToken);
+    }
   })
 }


### PR DESCRIPTION
#### What does  this PR do?

This PR adds an additional preview event restoration function. restoreUnusedPreviewToken added to main.js keeps the preview token event listener from being added back to game board sections with player tokens upon exiting the options menu.

#### Where should the reviewer start?

Familiarize yourself with the restoreUnusedPreviewToken function added to main.js.

### Is this a bug fix or a feature?

Bug fix.

#### How should this be manually tested?

In browser, occupy game board sections with player tokens and open the options menu. Upon exiting options menu, ensure that token occupied sections do not have mouseenter and mouseleave event listeners.
